### PR TITLE
Add dynamic metric_monitor.max_silent_time to device

### DIFF
--- a/app.lua
+++ b/app.lua
@@ -47,7 +47,8 @@ function create_device_if_needed(payload)
 					station_name = payload.station.name,
 					station_owner = payload.station.owner,
 					latitude = tostring(payload.position[1].latitude),
-					longitude = tostring(payload.position[1].longitude)
+					longitude = tostring(payload.position[1].longitude),
+					metric_monitor.max_silent_time = 2h
     				}
 			}
 			lynx.createDevice(_dev)

--- a/app.lua
+++ b/app.lua
@@ -48,7 +48,7 @@ function create_device_if_needed(payload)
 					station_owner = payload.station.owner,
 					latitude = tostring(payload.position[1].latitude),
 					longitude = tostring(payload.position[1].longitude),
-					metric_monitor.max_silent_time = 2h
+					["metric_monitor.max_silent_time"] = tostring(cfg.interval + 1) .. "h"
     				}
 			}
 			lynx.createDevice(_dev)


### PR DESCRIPTION
Adds metric_monitor.max_silent_time to app-related device metadata, dynamically calculated as cfg.interval + 1 hour to ensure monitoring of app functionality.